### PR TITLE
Implement POI detail route

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,7 @@ Environment variables are required for API access:
 ## Documentation
 
 Planning and requirements documentation can be found in the [llm-context](./llm-context/README.md) folder.
+
+### Routes
+
+The SPA uses React Router. Each POI on the map links to `/place/:placeId`, which renders a detailed view for that location.

--- a/src/PlacePage.jsx
+++ b/src/PlacePage.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { supabase } from './lib/supabaseClient';
+import ErrorToast from './components/ErrorToast';
 
 const PlacePage = () => {
   const { placeId } = useParams();
@@ -52,11 +53,7 @@ const PlacePage = () => {
   }
 
   if (error) {
-    return (
-      <div className="p-5 bg-[#fdf8f3] min-h-screen font-sans">
-        <p className="text-center text-red-500">{error}</p>
-      </div>
-    );
+    return <ErrorToast message={error} />;
   }
 
   if (!place) return null;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,32 +1,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import App from './App.jsx';
-import Login from './Login.jsx';
-import Registrar from './Registrar';
-import VistaLugar from './VistaLugar.jsx';
-import ListaFavoritos from './ListaFavoritos.jsx';
-import ListaLugarVisitado from './ListaLugarVisitado.jsx';
-import Sugerencias from './Sugerencias.jsx';
-import AgregarSitio from './AgregarSitio.jsx';
-import PlacePage from './PlacePage.jsx';
-import VistaBusqueda from './VistaBusqueda.jsx';
+import { RouterProvider } from 'react-router-dom';
+import router from './router.jsx';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <BrowserRouter>
-      <Routes>
-        <Route path="/" element={<App />} />
-        <Route path="/login" element={<Login />} />
-        <Route path="/registrar" element={<Registrar />} />
-        <Route path="/lugar" element={<VistaLugar />} />
-        <Route path="/sugerencias" element={<Sugerencias />} />
-        <Route path="/favoritos" element={<ListaFavoritos />} />
-        <Route path="/visitados" element={<ListaLugarVisitado />} />
-        <Route path="/agregar" element={<AgregarSitio />} />
-        <Route path="/place/:placeId" element={<PlacePage />} />
-        <Route path="/busqueda" element={<VistaBusqueda />} />
-      </Routes>
-    </BrowserRouter>
+        <RouterProvider router={router} />
   </React.StrictMode>
 );

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { createBrowserRouter } from 'react-router-dom';
+import App from './App.jsx';
+import Login from './Login.jsx';
+import Registrar from './Registrar';
+import VistaLugar from './VistaLugar.jsx';
+import ListaFavoritos from './ListaFavoritos.jsx';
+import ListaLugarVisitado from './ListaLugarVisitado.jsx';
+import Sugerencias from './Sugerencias.jsx';
+import AgregarSitio from './AgregarSitio.jsx';
+import PlacePage from './PlacePage.jsx';
+import VistaBusqueda from './VistaBusqueda.jsx';
+
+const router = createBrowserRouter([
+  { path: '/', element: <App /> },
+  { path: '/login', element: <Login /> },
+  { path: '/registrar', element: <Registrar /> },
+  { path: '/lugar', element: <VistaLugar /> },
+  { path: '/sugerencias', element: <Sugerencias /> },
+  { path: '/favoritos', element: <ListaFavoritos /> },
+  { path: '/visitados', element: <ListaLugarVisitado /> },
+  { path: '/agregar', element: <AgregarSitio /> },
+  { path: '/place/:placeId', element: <PlacePage /> },
+  { path: '/busqueda', element: <VistaBusqueda /> },
+]);
+
+export default router;

--- a/vite.config.js
+++ b/vite.config.js
@@ -43,6 +43,7 @@ export default defineConfig({
   //! == Development only to solve CORS issues ==
   //! This is a temporary solution for development purposes only.
   server: {
+    historyApiFallback: true,
     proxy: {
       '/opentripmap': {
         target: 'https://api.opentripmap.com/0.1/en',


### PR DESCRIPTION
## Summary
- add new `/place/:placeId` route configuration
- switch React Router setup to use a router object
- show a toast when a place ID is missing
- enable SPA fallback in the dev server
- document new route in README

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6845e929fcd8832db050ed67df3b8522