### PR TITLE
Add basic GPX route upload prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,7 @@ Planning and requirements documentation can be found in the [llm-context](./llm-
 ### Routes
 
 The SPA uses React Router. Each POI on the map links to `/place/:placeId`, which renders a detailed view for that location.
+
+### Routes (GPX Tracks)
+
+There is a basic prototype for uploading and listing GPS tracks. Use `/routes` to view existing routes and `/routes/upload` to upload a GPX file. Uploaded tracks are stored in the new `route` table in Supabase.

--- a/src/RoutesPage.jsx
+++ b/src/RoutesPage.jsx
@@ -1,0 +1,34 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { fetchRoutes } from './services/routeService';
+import './App.css';
+
+export default function RoutesPage() {
+  const navigate = useNavigate();
+  const [routes, setRoutes] = useState([]);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    fetchRoutes()
+      .then(setRoutes)
+      .catch(err => setError(err.message));
+  }, []);
+
+  return (
+    <div className="login-container">
+      <div className="login-hader">
+        <svg onClick={() => navigate('/')} xmlns="http://www.w3.org/2000/svg" width="24" height="24" className="back-arrow" viewBox="0 0 16 16">
+          <path fillRule="evenodd" d="M15 8a.5.5 0 0 0-.5-.5H2.707l3.147-3.146a.5.5 0 1 0-.708-.708l-4 4a.5.5 0 0 0 0 .708l4 4a.5.5 0 0 0 .708-.708L2.707 8.5H14.5A.5.5 0 0 0 15 8" />
+        </svg>
+      </div>
+      <h2 className="login-title">RUTAS</h2>
+      <button className="login-button" onClick={() => navigate('/routes/upload')}>Subir nueva ruta</button>
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+      <ul>
+        {routes.map(r => (
+          <li key={r.id}>{r.name} - {(r.distance_m/1000).toFixed(2)} km</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/UploadRoute.jsx
+++ b/src/UploadRoute.jsx
@@ -1,0 +1,41 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { uploadRoute } from './services/routeService';
+import './App.css';
+
+export default function UploadRoute() {
+  const navigate = useNavigate();
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+  const [file, setFile] = useState(null);
+  const [error, setError] = useState(null);
+
+  const handleSubmit = async () => {
+    if (!name || !file) {
+      setError('Falta nombre o archivo');
+      return;
+    }
+    try {
+      await uploadRoute({ name, description, gpxFile: file, activityType: 'hiking' });
+      navigate('/routes');
+    } catch (err) {
+      setError(err.message);
+    }
+  };
+
+  return (
+    <div className="login-container">
+      <div className="login-hader">
+        <svg onClick={() => navigate('/routes')} xmlns="http://www.w3.org/2000/svg" width="24" height="24" className="back-arrow" viewBox="0 0 16 16">
+          <path fillRule="evenodd" d="M15 8a.5.5 0 0 0-.5-.5H2.707l3.147-3.146a.5.5 0 1 0-.708-.708l-4 4a.5.5 0 0 0 0 .708l4 4a.5.5 0 0 0 .708-.708L2.707 8.5H14.5A.5.5 0 0 0 15 8" />
+        </svg>
+      </div>
+      <h2 className="login-title">SUBIR RUTA</h2>
+      <input className="login-input" placeholder="Nombre" value={name} onChange={e => setName(e.target.value)} />
+      <textarea className="login-input" placeholder="Descripción" value={description} onChange={e => setDescription(e.target.value)} />
+      <input type="file" accept=".gpx" onChange={e => setFile(e.target.files[0])} />
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+      <button className="login-button" onClick={handleSubmit}>Guardar</button>
+    </div>
+  );
+}

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -10,6 +10,8 @@ import Sugerencias from './Sugerencias.jsx';
 import AgregarSitio from './AgregarSitio.jsx';
 import PlacePage from './PlacePage.jsx';
 import VistaBusqueda from './VistaBusqueda.jsx';
+import RoutesPage from './RoutesPage.jsx';
+import UploadRoute from './UploadRoute.jsx';
 
 const router = createBrowserRouter([
   { path: '/', element: <App /> },
@@ -22,6 +24,8 @@ const router = createBrowserRouter([
   { path: '/agregar', element: <AgregarSitio /> },
   { path: '/place/:placeId', element: <PlacePage /> },
   { path: '/busqueda', element: <VistaBusqueda /> },
+  { path: '/routes', element: <RoutesPage /> },
+  { path: '/routes/upload', element: <UploadRoute /> },
 ]);
 
 export default router;

--- a/src/services/routeService.js
+++ b/src/services/routeService.js
@@ -1,0 +1,59 @@
+import { supabase } from '../lib/supabaseClient';
+
+// Parse GPX file and return array of [lon, lat] coordinates
+export async function parseGpxFile(file) {
+  const text = await file.text();
+  const parser = new DOMParser();
+  const xml = parser.parseFromString(text, 'application/xml');
+  const pts = Array.from(xml.getElementsByTagName('trkpt')).map(pt => [
+    parseFloat(pt.getAttribute('lon')),
+    parseFloat(pt.getAttribute('lat'))
+  ]);
+  if (pts.length === 0) throw new Error('GPX sin puntos de ruta');
+  return pts;
+}
+
+function haversineDistance([lon1, lat1], [lon2, lat2]) {
+  const R = 6371000; // metros
+  const toRad = deg => (deg * Math.PI) / 180;
+  const dLat = toRad(lat2 - lat1);
+  const dLon = toRad(lon2 - lon1);
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2;
+  return 2 * R * Math.asin(Math.sqrt(a));
+}
+
+function totalDistance(coords) {
+  let dist = 0;
+  for (let i = 1; i < coords.length; i++) {
+    dist += haversineDistance(coords[i - 1], coords[i]);
+  }
+  return dist;
+}
+
+export async function uploadRoute({ name, description, gpxFile, activityType }) {
+  const coordinates = await parseGpxFile(gpxFile);
+  const distance = totalDistance(coordinates);
+  const geo = { type: 'LineString', coordinates };
+
+  const { data, error } = await supabase
+    .from('route')
+    .insert({
+      name,
+      description,
+      activity_type: activityType,
+      distance_m: distance,
+      geo
+    })
+    .select();
+
+  if (error) throw error;
+  return data[0];
+}
+
+export async function fetchRoutes() {
+  const { data, error } = await supabase.from('route').select('*');
+  if (error) throw error;
+  return data;
+}


### PR DESCRIPTION
## Summary
- implement `routeService` with GPX parsing and Supabase upload
- add `RoutesPage` and `UploadRoute` pages
- wire new pages in router
- document new feature in README

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6849f1b412b0832daa7e78b20244ab0f